### PR TITLE
Lightfield - correcting units for the exposure time

### DIFF
--- a/src/qudi/hardware/spectrometer/lightfield_spectrometer.py
+++ b/src/qudi/hardware/spectrometer/lightfield_spectrometer.py
@@ -248,10 +248,7 @@ class Lightfield(SpectrometerInterface):
 
     @property
     def shutter_open(self) -> bool:
-        if (
-            self.shutter == "AlwaysOpen"
-            or self.shutter == "Normal"
-        ):
+        if self.shutter == "AlwaysOpen" or self.shutter == "Normal":
             return True
         else:
             return False
@@ -271,7 +268,12 @@ class Lightfield(SpectrometerInterface):
     @property
     def exposure_time(self) -> float:
         """Get the exposure time in seconds"""
-        return self._get_value(self.cam_setting.ShutterTimingExposureTime)
+
+        value_in_milliseconds = self._get_value(
+            self.cam_setting.ShutterTimingExposureTime
+        )
+
+        return float(value_in_milliseconds / 1e3)
 
     @exposure_time.setter
     def exposure_time(self, value: float):
@@ -282,7 +284,12 @@ class Lightfield(SpectrometerInterface):
             raise ValueError(
                 f"Exposure time {value} not in range [{self.exposure_time_limits['min']}, {self.exposure_time_limits['max']}]"
             )
-        self._set_value(self.cam_setting.ShutterTimingExposureTime, value)
+
+        value_in_milliseconds = value * 1e3
+
+        self._set_value(
+            self.cam_setting.ShutterTimingExposureTime, value_in_milliseconds
+        )
 
     def record_spectrum(self) -> np.ndarray:
         """Record a single spectrum and return it as a numpy array (2,N) where N is the number of pixels"""


### PR DESCRIPTION
## Description
Changes the exposure time to from seconds to milliseconds internally

## Motivation and Context
Fix bug

## How Has This Been Tested?
Yes

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
