### PR TITLE
Fix: Motor Dummy and Interface Cleanup

### DIFF
--- a/src/qudi/hardware/dummy/motor_dummy.py
+++ b/src/qudi/hardware/dummy/motor_dummy.py
@@ -61,7 +61,7 @@ class MotorDummy(MotorInterface):
     def on_deactivate(self):
         pass
 
-    def get_constraints(self):
+    def get_constraints(self) -> dict[str, dict[str, float | str | list[str] | None]]:
         axis0 = {'label': self._x_axis.label,
                  'unit': 'm',
                  'ramp': ['Sinus', 'Linear'],
@@ -121,7 +121,7 @@ class MotorDummy(MotorInterface):
             axis3['label']: axis3
         }
 
-    def move_rel(self,  param_dict):
+    def move_rel(self,  param_dict: dict[str, float]) -> None:
         curr_pos_dict = self.get_pos()
         constraints = self.get_constraints()
 
@@ -195,7 +195,7 @@ class MotorDummy(MotorInterface):
                 self._phi_axis.pos = self._phi_axis.pos + move_phi
 
 
-    def move_abs(self, param_dict):
+    def move_abs(self, param_dict: dict[str, float]) -> None:
         constraints = self.get_constraints()
 
         if param_dict.get(self._x_axis.label) is not None:
@@ -261,11 +261,10 @@ class MotorDummy(MotorInterface):
                 self._make_wait_after_movement()
                 self._phi_axis.pos = desired_pos
 
-    def abort(self):
+    def abort(self) -> None:
         self.log.info('MotorDummy: Movement stopped!')
-        return 0
 
-    def get_pos(self, param_list=None):
+    def get_pos(self, param_list: list[str] | None = None) -> dict[str, float]:
         pos = {}
         if param_list is not None:
             if self._x_axis.label in param_list:
@@ -288,7 +287,7 @@ class MotorDummy(MotorInterface):
 
         return pos
 
-    def get_status(self, param_list=None):
+    def get_status(self, param_list: list[str] | None = None) -> dict[str, int]:
         status = {}
         if param_list is not None:
             if self._x_axis.label in param_list:
@@ -311,7 +310,7 @@ class MotorDummy(MotorInterface):
 
         return status
 
-    def calibrate(self, param_list=None):
+    def calibrate(self, param_list: list[str] | None = None) -> None:
         if param_list is not None:
             if self._x_axis.label in param_list:
                 self._x_axis.pos = 0.0
@@ -331,9 +330,7 @@ class MotorDummy(MotorInterface):
             self._z_axis.pos = 0.0
             self._phi_axis.pos = 0.0
 
-        return 0
-
-    def get_velocity(self, param_list=None):
+    def get_velocity(self, param_list: list[str] | None = None) -> dict[str, float]:
         vel = {}
         if param_list is not None:
             if self._x_axis.label in param_list:
@@ -353,7 +350,7 @@ class MotorDummy(MotorInterface):
 
         return vel
 
-    def set_velocity(self, param_dict=None):
+    def set_velocity(self, param_dict: dict[str, float]) -> None:
         constraints = self.get_constraints()
 
         if param_dict.get(self._x_axis.label) is not None:

--- a/src/qudi/hardware/dummy/motor_dummy.py
+++ b/src/qudi/hardware/dummy/motor_dummy.py
@@ -30,7 +30,8 @@ from qudi.interface.motor_interface import MotorInterface
 
 @dataclass
 class MotorDummyAxis:
-    """ Generic dummy motor representing one axis. """
+    """Generic dummy motor representing one axis."""
+
     label: str
     pos: float = 0.0
     vel: float = 0.0
@@ -38,7 +39,7 @@ class MotorDummyAxis:
 
 
 class MotorDummy(MotorInterface):
-    """ This is the dummy class to simulate a motorized stage.
+    """This is the dummy class to simulate a motorized stage.
 
     Example config for copy-paste:
 
@@ -53,75 +54,83 @@ class MotorDummy(MotorInterface):
     wait_after_movement: float = ConfigOption(default=0.1)
 
     def on_activate(self):
-        self._x_axis = MotorDummyAxis('x')
-        self._y_axis = MotorDummyAxis('y')
-        self._z_axis = MotorDummyAxis('z')
-        self._phi_axis = MotorDummyAxis('phi')
+        self._x_axis = MotorDummyAxis("x")
+        self._y_axis = MotorDummyAxis("y")
+        self._z_axis = MotorDummyAxis("z")
+        self._phi_axis = MotorDummyAxis("phi")
 
     def on_deactivate(self):
         pass
 
     def get_constraints(self) -> dict[str, dict[str, float | str | list[str] | None]]:
-        axis0 = {'label': self._x_axis.label,
-                 'unit': 'm',
-                 'ramp': ['Sinus', 'Linear'],
-                 'pos_min': 0,
-                 'pos_max': 100,
-                 'pos_step': 0.001,
-                 'vel_min': 0,
-                 'vel_max': 100,
-                 'vel_step': 0.01,
-                 'acc_min': 0.1,
-                 'acc_max': 0.0,
-                 'acc_step': 0.0}
-
-        axis1 = {'label': self._y_axis.label,
-                 'unit': 'm',
-                 'ramp': ['Sinus', 'Linear'],
-                 'pos_min': 0,
-                 'pos_max': 100,
-                 'pos_step': 0.001,
-                 'vel_min': 0,
-                 'vel_max': 100,
-                 'vel_step': 0.01,
-                 'acc_min': 0.1,
-                 'acc_max': 0.0,
-                 'acc_step': 0.0}
-
-        axis2 = {'label': self._z_axis.label,
-                 'unit': 'm',
-                 'ramp': ['Sinus', 'Linear'],
-                 'pos_min': 0,
-                 'pos_max': 100,
-                 'pos_step': 0.001,
-                 'vel_min': 0,
-                 'vel_max': 100,
-                 'vel_step': 0.01,
-                 'acc_min': 0.1,
-                 'acc_max': 0.0,
-                 'acc_step': 0.0}
-
-        axis3 = {'label': self._phi_axis.label,
-                 'unit': '°',
-                 'ramp': ['Sinus', 'Trapez'],
-                 'pos_min': 0,
-                 'pos_max': 360,
-                 'pos_step': 0.1,
-                 'vel_min': 1,
-                 'vel_max': 20,
-                 'vel_step': 0.1,
-                 'acc_min': None,
-                 'acc_max': None,
-                 'acc_step': None}
-
-        return {
-            axis0['label']: axis0,
-            axis1['label']: axis1,
-            axis2['label']: axis2,
-            axis3['label']: axis3
+        axis0 = {
+            "label": self._x_axis.label,
+            "unit": "m",
+            "ramp": ["Sinus", "Linear"],
+            "pos_min": 0,
+            "pos_max": 100,
+            "pos_step": 0.001,
+            "vel_min": 0,
+            "vel_max": 100,
+            "vel_step": 0.01,
+            "acc_min": 0.1,
+            "acc_max": 0.0,
+            "acc_step": 0.0,
         }
 
-    def move_rel(self,  param_dict: dict[str, float]) -> None:
+        axis1 = {
+            "label": self._y_axis.label,
+            "unit": "m",
+            "ramp": ["Sinus", "Linear"],
+            "pos_min": 0,
+            "pos_max": 100,
+            "pos_step": 0.001,
+            "vel_min": 0,
+            "vel_max": 100,
+            "vel_step": 0.01,
+            "acc_min": 0.1,
+            "acc_max": 0.0,
+            "acc_step": 0.0,
+        }
+
+        axis2 = {
+            "label": self._z_axis.label,
+            "unit": "m",
+            "ramp": ["Sinus", "Linear"],
+            "pos_min": 0,
+            "pos_max": 100,
+            "pos_step": 0.001,
+            "vel_min": 0,
+            "vel_max": 100,
+            "vel_step": 0.01,
+            "acc_min": 0.1,
+            "acc_max": 0.0,
+            "acc_step": 0.0,
+        }
+
+        axis3 = {
+            "label": self._phi_axis.label,
+            "unit": "°",
+            "ramp": ["Sinus", "Trapez"],
+            "pos_min": 0,
+            "pos_max": 360,
+            "pos_step": 0.1,
+            "vel_min": 1,
+            "vel_max": 20,
+            "vel_step": 0.1,
+            "acc_min": None,
+            "acc_max": None,
+            "acc_step": None,
+        }
+
+        return {
+            axis0["label"]: axis0,
+            axis1["label"]: axis1,
+            axis2["label"]: axis2,
+            axis3["label"]: axis3,
+        }
+
+    def move_rel(self, param_dict: dict[str, float]) -> None:
         curr_pos_dict = self.get_pos()
         constraints = self.get_constraints()
 
@@ -129,15 +138,19 @@ class MotorDummy(MotorInterface):
             move_x = param_dict[self._x_axis.label]
             curr_pos_x = curr_pos_dict[self._x_axis.label]
 
-            if  (curr_pos_x + move_x > constraints[self._x_axis.label]['pos_max'] ) or\
-                (curr_pos_x + move_x < constraints[self._x_axis.label]['pos_min']):
-
-                self.log.warning('Cannot make further movement of the axis '
-                        '"{0}" with the step {1}, since the border [{2},{3}] '
-                        'was reached! Ignore command!'.format(
-                            self._x_axis.label, move_x,
-                            constraints[self._x_axis.label]['pos_min'],
-                            constraints[self._x_axis.label]['pos_max']))
+            if (curr_pos_x + move_x > constraints[self._x_axis.label]["pos_max"]) or (
+                curr_pos_x + move_x < constraints[self._x_axis.label]["pos_min"]
+            ):
+                self.log.warning(
+                    "Cannot make further movement of the axis "
+                    '"{0}" with the step {1}, since the border [{2},{3}] '
+                    "was reached! Ignore command!".format(
+                        self._x_axis.label,
+                        move_x,
+                        constraints[self._x_axis.label]["pos_min"],
+                        constraints[self._x_axis.label]["pos_max"],
+                    )
+                )
             else:
                 self._make_wait_after_movement()
                 self._x_axis.pos = self._x_axis.pos + move_x
@@ -146,15 +159,19 @@ class MotorDummy(MotorInterface):
             move_y = param_dict[self._y_axis.label]
             curr_pos_y = curr_pos_dict[self._y_axis.label]
 
-            if  (curr_pos_y + move_y > constraints[self._y_axis.label]['pos_max'] ) or\
-                (curr_pos_y + move_y < constraints[self._y_axis.label]['pos_min']):
-
-                self.log.warning('Cannot make further movement of the axis '
-                        '"{0}" with the step {1}, since the border [{2},{3}] '
-                        'was reached! Ignore command!'.format(
-                            self._y_axis.label, move_y,
-                            constraints[self._y_axis.label]['pos_min'],
-                            constraints[self._y_axis.label]['pos_max']))
+            if (curr_pos_y + move_y > constraints[self._y_axis.label]["pos_max"]) or (
+                curr_pos_y + move_y < constraints[self._y_axis.label]["pos_min"]
+            ):
+                self.log.warning(
+                    "Cannot make further movement of the axis "
+                    '"{0}" with the step {1}, since the border [{2},{3}] '
+                    "was reached! Ignore command!".format(
+                        self._y_axis.label,
+                        move_y,
+                        constraints[self._y_axis.label]["pos_min"],
+                        constraints[self._y_axis.label]["pos_max"],
+                    )
+                )
             else:
                 self._make_wait_after_movement()
                 self._y_axis.pos = self._y_axis.pos + move_y
@@ -163,37 +180,45 @@ class MotorDummy(MotorInterface):
             move_z = param_dict[self._z_axis.label]
             curr_pos_z = curr_pos_dict[self._z_axis.label]
 
-            if  (curr_pos_z + move_z > constraints[self._z_axis.label]['pos_max'] ) or\
-                (curr_pos_z + move_z < constraints[self._z_axis.label]['pos_min']):
-
-                self.log.warning('Cannot make further movement of the axis '
-                        '"{0}" with the step {1}, since the border [{2},{3}] '
-                        'was reached! Ignore command!'.format(
-                            self._z_axis.label, move_z,
-                            constraints[self._z_axis.label]['pos_min'],
-                            constraints[self._z_axis.label]['pos_max']))
+            if (curr_pos_z + move_z > constraints[self._z_axis.label]["pos_max"]) or (
+                curr_pos_z + move_z < constraints[self._z_axis.label]["pos_min"]
+            ):
+                self.log.warning(
+                    "Cannot make further movement of the axis "
+                    '"{0}" with the step {1}, since the border [{2},{3}] '
+                    "was reached! Ignore command!".format(
+                        self._z_axis.label,
+                        move_z,
+                        constraints[self._z_axis.label]["pos_min"],
+                        constraints[self._z_axis.label]["pos_max"],
+                    )
+                )
             else:
                 self._make_wait_after_movement()
                 self._z_axis.pos = self._z_axis.pos + move_z
-
 
         if param_dict.get(self._phi_axis.label) is not None:
             move_phi = param_dict[self._phi_axis.label]
             curr_pos_phi = curr_pos_dict[self._phi_axis.label]
 
-            if  (curr_pos_phi + move_phi > constraints[self._phi_axis.label]['pos_max'] ) or\
-                (curr_pos_phi + move_phi < constraints[self._phi_axis.label]['pos_min']):
-
-                self.log.warning('Cannot make further movement of the axis '
-                        '"{0}" with the step {1}, since the border [{2},{3}] '
-                        'was reached! Ignore command!'.format(
-                            self._phi_axis.label, move_phi,
-                            constraints[self._phi_axis.label]['pos_min'],
-                            constraints[self._phi_axis.label]['pos_max']))
+            if (
+                curr_pos_phi + move_phi > constraints[self._phi_axis.label]["pos_max"]
+            ) or (
+                curr_pos_phi + move_phi < constraints[self._phi_axis.label]["pos_min"]
+            ):
+                self.log.warning(
+                    "Cannot make further movement of the axis "
+                    '"{0}" with the step {1}, since the border [{2},{3}] '
+                    "was reached! Ignore command!".format(
+                        self._phi_axis.label,
+                        move_phi,
+                        constraints[self._phi_axis.label]["pos_min"],
+                        constraints[self._phi_axis.label]["pos_max"],
+                    )
+                )
             else:
                 self._make_wait_after_movement()
                 self._phi_axis.pos = self._phi_axis.pos + move_phi
-
 
     def move_abs(self, param_dict: dict[str, float]) -> None:
         constraints = self.get_constraints()
@@ -202,67 +227,80 @@ class MotorDummy(MotorInterface):
             desired_pos = param_dict[self._x_axis.label]
             constr = constraints[self._x_axis.label]
 
-            if not(constr['pos_min'] <= desired_pos <= constr['pos_max']):
-                self.log.warning('Cannot make absolute movement of the axis '
-                        '"{0}" to possition {1}, since it exceeds the limits '
-                        '[{2},{3}] ! Command is ignored!'.format(
-                            self._x_axis.label, desired_pos,
-                            constr['pos_min'],
-                            constr['pos_max']))
+            if not (constr["pos_min"] <= desired_pos <= constr["pos_max"]):
+                self.log.warning(
+                    "Cannot make absolute movement of the axis "
+                    '"{0}" to possition {1}, since it exceeds the limits '
+                    "[{2},{3}] ! Command is ignored!".format(
+                        self._x_axis.label,
+                        desired_pos,
+                        constr["pos_min"],
+                        constr["pos_max"],
+                    )
+                )
             else:
                 self._make_wait_after_movement()
                 self._x_axis.pos = desired_pos
-
 
         if param_dict.get(self._y_axis.label) is not None:
             desired_pos = param_dict[self._y_axis.label]
             constr = constraints[self._y_axis.label]
 
-            if not(constr['pos_min'] <= desired_pos <= constr['pos_max']):
-                self.log.warning('Cannot make absolute movement of the axis '
-                        '"{0}" to possition {1}, since it exceeds the limits '
-                        '[{2},{3}] ! Command is ignored!'.format(
-                            self._y_axis.label, desired_pos,
-                            constr['pos_min'],
-                            constr['pos_max']))
+            if not (constr["pos_min"] <= desired_pos <= constr["pos_max"]):
+                self.log.warning(
+                    "Cannot make absolute movement of the axis "
+                    '"{0}" to possition {1}, since it exceeds the limits '
+                    "[{2},{3}] ! Command is ignored!".format(
+                        self._y_axis.label,
+                        desired_pos,
+                        constr["pos_min"],
+                        constr["pos_max"],
+                    )
+                )
             else:
                 self._make_wait_after_movement()
                 self._y_axis.pos = desired_pos
-
 
         if param_dict.get(self._z_axis.label) is not None:
             desired_pos = param_dict[self._z_axis.label]
             constr = constraints[self._z_axis.label]
 
-            if not(constr['pos_min'] <= desired_pos <= constr['pos_max']):
-                self.log.warning('Cannot make absolute movement of the axis '
-                        '"{0}" to possition {1}, since it exceeds the limits '
-                        '[{2},{3}] ! Command is ignored!'.format(
-                            self._z_axis.label, desired_pos,
-                            constr['pos_min'],
-                            constr['pos_max']))
+            if not (constr["pos_min"] <= desired_pos <= constr["pos_max"]):
+                self.log.warning(
+                    "Cannot make absolute movement of the axis "
+                    '"{0}" to possition {1}, since it exceeds the limits '
+                    "[{2},{3}] ! Command is ignored!".format(
+                        self._z_axis.label,
+                        desired_pos,
+                        constr["pos_min"],
+                        constr["pos_max"],
+                    )
+                )
             else:
                 self._make_wait_after_movement()
                 self._z_axis.pos = desired_pos
-
 
         if param_dict.get(self._phi_axis.label) is not None:
             desired_pos = param_dict[self._phi_axis.label]
             constr = constraints[self._phi_axis.label]
 
-            if not(constr['pos_min'] <= desired_pos <= constr['pos_max']):
-                self.log.warning('Cannot make absolute movement of the axis '
-                        '"{0}" to possition {1}, since it exceeds the limits '
-                        '[{2},{3}] ! Command is ignored!'.format(
-                            self._phi_axis.label, desired_pos,
-                            constr['pos_min'],
-                            constr['pos_max']))
+            if not (constr["pos_min"] <= desired_pos <= constr["pos_max"]):
+                self.log.warning(
+                    "Cannot make absolute movement of the axis "
+                    '"{0}" to possition {1}, since it exceeds the limits '
+                    "[{2},{3}] ! Command is ignored!".format(
+                        self._phi_axis.label,
+                        desired_pos,
+                        constr["pos_min"],
+                        constr["pos_max"],
+                    )
+                )
             else:
                 self._make_wait_after_movement()
                 self._phi_axis.pos = desired_pos
 
     def abort(self) -> None:
-        self.log.info('MotorDummy: Movement stopped!')
+        self.log.info("MotorDummy: Movement stopped!")
 
     def get_pos(self, param_list: list[str] | None = None) -> dict[str, float]:
         pos = {}
@@ -357,13 +395,17 @@ class MotorDummy(MotorInterface):
             desired_vel = param_dict[self._x_axis.label]
             constr = constraints[self._x_axis.label]
 
-            if not(constr['vel_min'] <= desired_vel <= constr['vel_max']):
-                self.log.warning('Cannot set velocity of the axis '
-                        '"{0}" to possition {1}, since it exceeds the limits '
-                        '[{2},{3}] ! Command is ignored!'.format(
-                            self._x_axis.label, desired_vel,
-                            constr['vel_min'],
-                            constr['vel_max']))
+            if not (constr["vel_min"] <= desired_vel <= constr["vel_max"]):
+                self.log.warning(
+                    "Cannot set velocity of the axis "
+                    '"{0}" to possition {1}, since it exceeds the limits '
+                    "[{2},{3}] ! Command is ignored!".format(
+                        self._x_axis.label,
+                        desired_vel,
+                        constr["vel_min"],
+                        constr["vel_max"],
+                    )
+                )
             else:
                 self._x_axis.vel = desired_vel
 
@@ -371,13 +413,17 @@ class MotorDummy(MotorInterface):
             desired_vel = param_dict[self._y_axis.label]
             constr = constraints[self._y_axis.label]
 
-            if not(constr['vel_min'] <= desired_vel <= constr['vel_max']):
-                self.log.warning('Cannot set velocity of the axis '
-                        '"{0}" to possition {1}, since it exceeds the limits '
-                        '[{2},{3}] ! Command is ignored!'.format(
-                            self._y_axis.label, desired_vel,
-                            constr['vel_min'],
-                            constr['vel_max']))
+            if not (constr["vel_min"] <= desired_vel <= constr["vel_max"]):
+                self.log.warning(
+                    "Cannot set velocity of the axis "
+                    '"{0}" to possition {1}, since it exceeds the limits '
+                    "[{2},{3}] ! Command is ignored!".format(
+                        self._y_axis.label,
+                        desired_vel,
+                        constr["vel_min"],
+                        constr["vel_max"],
+                    )
+                )
             else:
                 self._y_axis.vel = desired_vel
 
@@ -385,13 +431,17 @@ class MotorDummy(MotorInterface):
             desired_vel = param_dict[self._z_axis.label]
             constr = constraints[self._z_axis.label]
 
-            if not(constr['vel_min'] <= desired_vel <= constr['vel_max']):
-                self.log.warning('Cannot set velocity of the axis '
-                        '"{0}" to possition {1}, since it exceeds the limits '
-                        '[{2},{3}] ! Command is ignored!'.format(
-                            self._z_axis.label, desired_vel,
-                            constr['vel_min'],
-                            constr['vel_max']))
+            if not (constr["vel_min"] <= desired_vel <= constr["vel_max"]):
+                self.log.warning(
+                    "Cannot set velocity of the axis "
+                    '"{0}" to possition {1}, since it exceeds the limits '
+                    "[{2},{3}] ! Command is ignored!".format(
+                        self._z_axis.label,
+                        desired_vel,
+                        constr["vel_min"],
+                        constr["vel_max"],
+                    )
+                )
             else:
                 self._z_axis.vel = desired_vel
 
@@ -399,17 +449,20 @@ class MotorDummy(MotorInterface):
             desired_vel = param_dict[self._phi_axis.label]
             constr = constraints[self._phi_axis.label]
 
-            if not(constr['vel_min'] <= desired_vel <= constr['vel_max']):
-                self.log.warning('Cannot set velocity of the axis '
-                        '"{0}" to possition {1}, since it exceeds the limits '
-                        '[{2},{3}] ! Command is ignored!'.format(
-                            self._phi_axis.label, desired_vel,
-                            constr['pos_min'],
-                            constr['pos_max']))
+            if not (constr["vel_min"] <= desired_vel <= constr["vel_max"]):
+                self.log.warning(
+                    "Cannot set velocity of the axis "
+                    '"{0}" to possition {1}, since it exceeds the limits '
+                    "[{2},{3}] ! Command is ignored!".format(
+                        self._phi_axis.label,
+                        desired_vel,
+                        constr["pos_min"],
+                        constr["pos_max"],
+                    )
+                )
             else:
                 self._phi_axis.vel = desired_vel
 
     def _make_wait_after_movement(self):
-        """ Define a time which the dummy should wait after each movement. """
+        """Define a time which the dummy should wait after each movement."""
         time.sleep(self.wait_after_movement)
-

--- a/src/qudi/hardware/dummy/motor_dummy.py
+++ b/src/qudi/hardware/dummy/motor_dummy.py
@@ -24,8 +24,6 @@ import time
 from collections import OrderedDict
 from dataclasses import dataclass
 
-from qudi.core.module import Base
-
 from qudi.interface.motor_interface import MotorInterface
 
 
@@ -38,7 +36,7 @@ class MotorDummyAxis:
     status: int = 0
 
 
-class MotorDummy(Base, MotorInterface):
+class MotorDummy(MotorInterface):
     """ This is the dummy class to simulate a motorized stage.
 
     Example config for copy-paste:

--- a/src/qudi/hardware/dummy/motor_dummy.py
+++ b/src/qudi/hardware/dummy/motor_dummy.py
@@ -58,12 +58,13 @@ class MotorDummy(MotorInterface):
         self._y_axis = MotorDummyAxis("y")
         self._z_axis = MotorDummyAxis("z")
         self._phi_axis = MotorDummyAxis("phi")
+        self._axes = [self._x_axis, self._y_axis, self._z_axis, self._phi_axis]
 
     def on_deactivate(self):
         pass
 
     def get_constraints(self) -> dict[str, dict[str, float | str | list[str] | None]]:
-        axis0 = {
+        x_constraints = {
             "label": self._x_axis.label,
             "unit": "m",
             "ramp": ["Sinus", "Linear"],
@@ -77,8 +78,7 @@ class MotorDummy(MotorInterface):
             "acc_max": 0.0,
             "acc_step": 0.0,
         }
-
-        axis1 = {
+        y_constraints = {
             "label": self._y_axis.label,
             "unit": "m",
             "ramp": ["Sinus", "Linear"],
@@ -92,8 +92,7 @@ class MotorDummy(MotorInterface):
             "acc_max": 0.0,
             "acc_step": 0.0,
         }
-
-        axis2 = {
+        z_constraints = {
             "label": self._z_axis.label,
             "unit": "m",
             "ramp": ["Sinus", "Linear"],
@@ -107,8 +106,7 @@ class MotorDummy(MotorInterface):
             "acc_max": 0.0,
             "acc_step": 0.0,
         }
-
-        axis3 = {
+        phi_constraints = {
             "label": self._phi_axis.label,
             "unit": "°",
             "ramp": ["Sinus", "Trapez"],
@@ -122,346 +120,146 @@ class MotorDummy(MotorInterface):
             "acc_max": None,
             "acc_step": None,
         }
-
         return {
-            axis0["label"]: axis0,
-            axis1["label"]: axis1,
-            axis2["label"]: axis2,
-            axis3["label"]: axis3,
+            x_constraints["label"]: x_constraints,
+            y_constraints["label"]: y_constraints,
+            z_constraints["label"]: z_constraints,
+            phi_constraints["label"]: phi_constraints,
         }
 
     def move_rel(self, param_dict: dict[str, float]) -> None:
-        curr_pos_dict = self.get_pos()
+        if not param_dict:
+            return
+
+        cur_pos_dict = self.get_pos()
         constraints = self.get_constraints()
 
-        if param_dict.get(self._x_axis.label) is not None:
-            move_x = param_dict[self._x_axis.label]
-            curr_pos_x = curr_pos_dict[self._x_axis.label]
+        for axis in self._axes:
+            distance = param_dict.get(axis.label)
+            if distance is None:
+                continue
 
-            if (curr_pos_x + move_x > constraints[self._x_axis.label]["pos_max"]) or (
-                curr_pos_x + move_x < constraints[self._x_axis.label]["pos_min"]
-            ):
+            cur_constraints = constraints[axis.label]
+            pos_min = cur_constraints["pos_min"]
+            pos_max = cur_constraints["pos_max"]
+            desired_pos = cur_pos_dict[axis.label] + distance
+            if not (pos_min <= desired_pos <= pos_max):
                 self.log.warning(
-                    "Cannot make further movement of the axis "
-                    '"{0}" with the step {1}, since the border [{2},{3}] '
-                    "was reached! Ignore command!".format(
-                        self._x_axis.label,
-                        move_x,
-                        constraints[self._x_axis.label]["pos_min"],
-                        constraints[self._x_axis.label]["pos_max"],
-                    )
+                    f"Cannot make further movement of the axis "
+                    f'"{axis.label}" with the step {distance}, '
+                    f"since the border [{pos_min},{pos_max}] "
+                    "was reached. Ignoring the command!"
                 )
             else:
                 self._make_wait_after_movement()
-                self._x_axis.pos = self._x_axis.pos + move_x
-
-        if param_dict.get(self._y_axis.label) is not None:
-            move_y = param_dict[self._y_axis.label]
-            curr_pos_y = curr_pos_dict[self._y_axis.label]
-
-            if (curr_pos_y + move_y > constraints[self._y_axis.label]["pos_max"]) or (
-                curr_pos_y + move_y < constraints[self._y_axis.label]["pos_min"]
-            ):
-                self.log.warning(
-                    "Cannot make further movement of the axis "
-                    '"{0}" with the step {1}, since the border [{2},{3}] '
-                    "was reached! Ignore command!".format(
-                        self._y_axis.label,
-                        move_y,
-                        constraints[self._y_axis.label]["pos_min"],
-                        constraints[self._y_axis.label]["pos_max"],
-                    )
-                )
-            else:
-                self._make_wait_after_movement()
-                self._y_axis.pos = self._y_axis.pos + move_y
-
-        if param_dict.get(self._z_axis.label) is not None:
-            move_z = param_dict[self._z_axis.label]
-            curr_pos_z = curr_pos_dict[self._z_axis.label]
-
-            if (curr_pos_z + move_z > constraints[self._z_axis.label]["pos_max"]) or (
-                curr_pos_z + move_z < constraints[self._z_axis.label]["pos_min"]
-            ):
-                self.log.warning(
-                    "Cannot make further movement of the axis "
-                    '"{0}" with the step {1}, since the border [{2},{3}] '
-                    "was reached! Ignore command!".format(
-                        self._z_axis.label,
-                        move_z,
-                        constraints[self._z_axis.label]["pos_min"],
-                        constraints[self._z_axis.label]["pos_max"],
-                    )
-                )
-            else:
-                self._make_wait_after_movement()
-                self._z_axis.pos = self._z_axis.pos + move_z
-
-        if param_dict.get(self._phi_axis.label) is not None:
-            move_phi = param_dict[self._phi_axis.label]
-            curr_pos_phi = curr_pos_dict[self._phi_axis.label]
-
-            if (
-                curr_pos_phi + move_phi > constraints[self._phi_axis.label]["pos_max"]
-            ) or (
-                curr_pos_phi + move_phi < constraints[self._phi_axis.label]["pos_min"]
-            ):
-                self.log.warning(
-                    "Cannot make further movement of the axis "
-                    '"{0}" with the step {1}, since the border [{2},{3}] '
-                    "was reached! Ignore command!".format(
-                        self._phi_axis.label,
-                        move_phi,
-                        constraints[self._phi_axis.label]["pos_min"],
-                        constraints[self._phi_axis.label]["pos_max"],
-                    )
-                )
-            else:
-                self._make_wait_after_movement()
-                self._phi_axis.pos = self._phi_axis.pos + move_phi
+                axis.pos = desired_pos
 
     def move_abs(self, param_dict: dict[str, float]) -> None:
+        if not param_dict:
+            return
+
         constraints = self.get_constraints()
 
-        if param_dict.get(self._x_axis.label) is not None:
-            desired_pos = param_dict[self._x_axis.label]
-            constr = constraints[self._x_axis.label]
+        for axis in self._axes:
+            desired_pos = param_dict.get(axis.label)
+            if desired_pos is None:
+                continue
 
-            if not (constr["pos_min"] <= desired_pos <= constr["pos_max"]):
+            cur_constraints = constraints[axis.label]
+            pos_min = cur_constraints["pos_min"]
+            pos_max = cur_constraints["pos_max"]
+            if not (pos_min <= desired_pos <= pos_max):
                 self.log.warning(
-                    "Cannot make absolute movement of the axis "
-                    '"{0}" to possition {1}, since it exceeds the limits '
-                    "[{2},{3}] ! Command is ignored!".format(
-                        self._x_axis.label,
-                        desired_pos,
-                        constr["pos_min"],
-                        constr["pos_max"],
-                    )
+                    f"Cannot make absolute movement of the axis "
+                    f'"{axis.label}" to position {desired_pos}, '
+                    f"since it exceeds the limits "
+                    f"[{pos_min},{pos_max}]. Ignoring the command!"
                 )
             else:
                 self._make_wait_after_movement()
-                self._x_axis.pos = desired_pos
-
-        if param_dict.get(self._y_axis.label) is not None:
-            desired_pos = param_dict[self._y_axis.label]
-            constr = constraints[self._y_axis.label]
-
-            if not (constr["pos_min"] <= desired_pos <= constr["pos_max"]):
-                self.log.warning(
-                    "Cannot make absolute movement of the axis "
-                    '"{0}" to possition {1}, since it exceeds the limits '
-                    "[{2},{3}] ! Command is ignored!".format(
-                        self._y_axis.label,
-                        desired_pos,
-                        constr["pos_min"],
-                        constr["pos_max"],
-                    )
-                )
-            else:
-                self._make_wait_after_movement()
-                self._y_axis.pos = desired_pos
-
-        if param_dict.get(self._z_axis.label) is not None:
-            desired_pos = param_dict[self._z_axis.label]
-            constr = constraints[self._z_axis.label]
-
-            if not (constr["pos_min"] <= desired_pos <= constr["pos_max"]):
-                self.log.warning(
-                    "Cannot make absolute movement of the axis "
-                    '"{0}" to possition {1}, since it exceeds the limits '
-                    "[{2},{3}] ! Command is ignored!".format(
-                        self._z_axis.label,
-                        desired_pos,
-                        constr["pos_min"],
-                        constr["pos_max"],
-                    )
-                )
-            else:
-                self._make_wait_after_movement()
-                self._z_axis.pos = desired_pos
-
-        if param_dict.get(self._phi_axis.label) is not None:
-            desired_pos = param_dict[self._phi_axis.label]
-            constr = constraints[self._phi_axis.label]
-
-            if not (constr["pos_min"] <= desired_pos <= constr["pos_max"]):
-                self.log.warning(
-                    "Cannot make absolute movement of the axis "
-                    '"{0}" to possition {1}, since it exceeds the limits '
-                    "[{2},{3}] ! Command is ignored!".format(
-                        self._phi_axis.label,
-                        desired_pos,
-                        constr["pos_min"],
-                        constr["pos_max"],
-                    )
-                )
-            else:
-                self._make_wait_after_movement()
-                self._phi_axis.pos = desired_pos
+                axis.pos = desired_pos
 
     def abort(self) -> None:
         self.log.info("MotorDummy: Movement stopped!")
 
     def get_pos(self, param_list: list[str] | None = None) -> dict[str, float]:
+        if param_list is None:
+            return {
+                self._x_axis.label: self._x_axis.pos,
+                self._y_axis.label: self._y_axis.pos,
+                self._z_axis.label: self._z_axis.pos,
+                self._phi_axis.label: self._phi_axis.pos,
+            }
+
         pos = {}
-        if param_list is not None:
-            if self._x_axis.label in param_list:
-                pos[self._x_axis.label] = self._x_axis.pos
-
-            if self._y_axis.label in param_list:
-                pos[self._y_axis.label] = self._y_axis.pos
-
-            if self._z_axis.label in param_list:
-                pos[self._z_axis.label] = self._z_axis.pos
-
-            if self._phi_axis.label in param_list:
-                pos[self._phi_axis.label] = self._phi_axis.pos
-
-        else:
-            pos[self._x_axis.label] = self._x_axis.pos
-            pos[self._y_axis.label] = self._y_axis.pos
-            pos[self._z_axis.label] = self._z_axis.pos
-            pos[self._phi_axis.label] = self._phi_axis.pos
-
+        for axis in self._axes:
+            if axis.label in param_list:
+                pos[axis.label] = axis.pos
         return pos
 
     def get_status(self, param_list: list[str] | None = None) -> dict[str, int]:
+        # In the dummy, the status is always 0 (OK)
+        if param_list is None:
+            return {
+                self._x_axis.label: self._x_axis.status,
+                self._y_axis.label: self._y_axis.status,
+                self._z_axis.label: self._z_axis.status,
+                self._phi_axis.label: self._phi_axis.status,
+            }
+
         status = {}
-        if param_list is not None:
-            if self._x_axis.label in param_list:
-                status[self._x_axis.label] = self._x_axis.status
-
-            if self._y_axis.label in param_list:
-                status[self._y_axis.label] = self._y_axis.status
-
-            if self._z_axis.label in param_list:
-                status[self._z_axis.label] = self._z_axis.status
-
-            if self._phi_axis.label in param_list:
-                status[self._phi_axis.label] = self._phi_axis.status
-
-        else:
-            status[self._x_axis.label] = self._x_axis.status
-            status[self._y_axis.label] = self._y_axis.status
-            status[self._z_axis.label] = self._z_axis.status
-            status[self._phi_axis.label] = self._phi_axis.status
-
+        for axis in self._axes:
+            if axis.label in param_list:
+                status[axis.label] = axis.status
         return status
 
     def calibrate(self, param_list: list[str] | None = None) -> None:
-        if param_list is not None:
-            if self._x_axis.label in param_list:
-                self._x_axis.pos = 0.0
-
-            if self._y_axis.label in param_list:
-                self._y_axis.pos = 0.0
-
-            if self._z_axis.label in param_list:
-                self._z_axis.pos = 0.0
-
-            if self._phi_axis.label in param_list:
-                self._phi_axis.pos = 0.0
-
+        if param_list is None:
+            for axis in self._axes:
+                axis.pos = 0.0
         else:
-            self._x_axis.pos = 0.0
-            self._y_axis.pos = 0.0
-            self._z_axis.pos = 0.0
-            self._phi_axis.pos = 0.0
+            for axis in self._axes:
+                if axis.label in param_list:
+                    axis.pos = 0.0
 
     def get_velocity(self, param_list: list[str] | None = None) -> dict[str, float]:
-        vel = {}
-        if param_list is not None:
-            if self._x_axis.label in param_list:
-                vel[self._x_axis.label] = self._x_axis.vel
-            if self._y_axis.label in param_list:
-                vel[self._y_axis.label] = self._y_axis.vel
-            if self._z_axis.label in param_list:
-                vel[self._z_axis.label] = self._z_axis.vel
-            if self._phi_axis.label in param_list:
-                vel[self._phi_axis.label] = self._phi_axis.vel
+        if param_list is None:
+            return {
+                self._x_axis.label: self._x_axis.vel,
+                self._y_axis.label: self._y_axis.vel,
+                self._z_axis.label: self._z_axis.vel,
+                self._phi_axis.label: self._phi_axis.vel,
+            }
 
-        else:
-            vel[self._x_axis.label] = self._x_axis.vel
-            vel[self._y_axis.label] = self._y_axis.vel
-            vel[self._z_axis.label] = self._z_axis.vel
-            vel[self._phi_axis.label] = self._phi_axis.vel
-
-        return vel
+        velocity = {}
+        for axis in self._axes:
+            if axis.label in param_list:
+                velocity[axis.label] = axis.vel
+        return velocity
 
     def set_velocity(self, param_dict: dict[str, float]) -> None:
+        if not param_dict:
+            return
+
         constraints = self.get_constraints()
 
-        if param_dict.get(self._x_axis.label) is not None:
-            desired_vel = param_dict[self._x_axis.label]
-            constr = constraints[self._x_axis.label]
+        for axis in self._axes:
+            desired_vel = param_dict.get(axis.label)
+            if desired_vel is None:
+                continue
 
-            if not (constr["vel_min"] <= desired_vel <= constr["vel_max"]):
+            cur_constraints = constraints[axis.label]
+            vel_min = cur_constraints["vel_min"]
+            vel_max = cur_constraints["vel_max"]
+            if not (vel_min <= desired_vel <= vel_max):
                 self.log.warning(
-                    "Cannot set velocity of the axis "
-                    '"{0}" to possition {1}, since it exceeds the limits '
-                    "[{2},{3}] ! Command is ignored!".format(
-                        self._x_axis.label,
-                        desired_vel,
-                        constr["vel_min"],
-                        constr["vel_max"],
-                    )
+                    f"Cannot set velocity of the axis "
+                    f'"{axis.label}" to {desired_vel}, '
+                    f"since it exceeds the limits "
+                    f"[{vel_min},{vel_max}]. Ignoring the command!"
                 )
             else:
-                self._x_axis.vel = desired_vel
-
-        if param_dict.get(self._y_axis.label) is not None:
-            desired_vel = param_dict[self._y_axis.label]
-            constr = constraints[self._y_axis.label]
-
-            if not (constr["vel_min"] <= desired_vel <= constr["vel_max"]):
-                self.log.warning(
-                    "Cannot set velocity of the axis "
-                    '"{0}" to possition {1}, since it exceeds the limits '
-                    "[{2},{3}] ! Command is ignored!".format(
-                        self._y_axis.label,
-                        desired_vel,
-                        constr["vel_min"],
-                        constr["vel_max"],
-                    )
-                )
-            else:
-                self._y_axis.vel = desired_vel
-
-        if param_dict.get(self._z_axis.label) is not None:
-            desired_vel = param_dict[self._z_axis.label]
-            constr = constraints[self._z_axis.label]
-
-            if not (constr["vel_min"] <= desired_vel <= constr["vel_max"]):
-                self.log.warning(
-                    "Cannot set velocity of the axis "
-                    '"{0}" to possition {1}, since it exceeds the limits '
-                    "[{2},{3}] ! Command is ignored!".format(
-                        self._z_axis.label,
-                        desired_vel,
-                        constr["vel_min"],
-                        constr["vel_max"],
-                    )
-                )
-            else:
-                self._z_axis.vel = desired_vel
-
-        if param_dict.get(self._phi_axis.label) is not None:
-            desired_vel = param_dict[self._phi_axis.label]
-            constr = constraints[self._phi_axis.label]
-
-            if not (constr["vel_min"] <= desired_vel <= constr["vel_max"]):
-                self.log.warning(
-                    "Cannot set velocity of the axis "
-                    '"{0}" to possition {1}, since it exceeds the limits '
-                    "[{2},{3}] ! Command is ignored!".format(
-                        self._phi_axis.label,
-                        desired_vel,
-                        constr["pos_min"],
-                        constr["pos_max"],
-                    )
-                )
-            else:
-                self._phi_axis.vel = desired_vel
+                axis.vel = desired_vel
 
     def _make_wait_after_movement(self):
         """Define a time which the dummy should wait after each movement."""

--- a/src/qudi/hardware/dummy/motor_dummy.py
+++ b/src/qudi/hardware/dummy/motor_dummy.py
@@ -76,7 +76,7 @@ class MotorDummy(MotorInterface):
             "vel_max": 100,
             "vel_step": 0.01,
             "acc_min": 0.1,
-            "acc_max": 0.0,
+            "acc_max": 1000.0,
             "acc_step": 0.0,
         }
         y_constraints = {
@@ -90,7 +90,7 @@ class MotorDummy(MotorInterface):
             "vel_max": 100,
             "vel_step": 0.01,
             "acc_min": 0.1,
-            "acc_max": 0.0,
+            "acc_max": 100.0,
             "acc_step": 0.0,
         }
         z_constraints = {
@@ -104,7 +104,7 @@ class MotorDummy(MotorInterface):
             "vel_max": 100,
             "vel_step": 0.01,
             "acc_min": 0.1,
-            "acc_max": 0.0,
+            "acc_max": 100.0,
             "acc_step": 0.0,
         }
         phi_constraints = {

--- a/src/qudi/hardware/dummy/motor_dummy.py
+++ b/src/qudi/hardware/dummy/motor_dummy.py
@@ -20,17 +20,22 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 
-from collections import OrderedDict
 import time
+from collections import OrderedDict
+from dataclasses import dataclass
 
 from qudi.core.module import Base
+
 from qudi.interface.motor_interface import MotorInterface
 
 
-class MotorAxisDummy:
+@dataclass
+class MotorDummyAxis:
     """ Generic dummy motor representing one axis. """
-    def __init__(self, label):
-        self.label = label
+    label: str
+    pos: float = 0.0
+    vel: float = 0.0
+    status: int = 0
 
 
 class MotorDummy(Base, MotorInterface):
@@ -39,7 +44,7 @@ class MotorDummy(Base, MotorInterface):
     Example config for copy-paste:
 
     motor_dummy:
-        module.Class: 'motor.motor_dummy.MotorDummy'
+        module.Class: 'dummy.motor_dummy.MotorDummy'
 
     """
 
@@ -50,10 +55,10 @@ class MotorDummy(Base, MotorInterface):
                          "Use with caution and contribute bug fixed back, please.")
 
         # these label should be actually set by the config.
-        self._x_axis = MotorAxisDummy('x')
-        self._y_axis = MotorAxisDummy('y')
-        self._z_axis = MotorAxisDummy('z')
-        self._phi_axis = MotorAxisDummy('phi')
+        self._x_axis = MotorDummyAxis('x')
+        self._y_axis = MotorDummyAxis('y')
+        self._z_axis = MotorDummyAxis('z')
+        self._phi_axis = MotorDummyAxis('phi')
 
         self._wait_after_movement = 1 #in seconds
 

--- a/src/qudi/hardware/dummy/motor_dummy.py
+++ b/src/qudi/hardware/dummy/motor_dummy.py
@@ -19,6 +19,7 @@ See the GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with qudi.
 If not, see <https://www.gnu.org/licenses/>.
 """
+from __future__ import annotations
 
 import time
 from dataclasses import dataclass

--- a/src/qudi/hardware/dummy/motor_dummy.py
+++ b/src/qudi/hardware/dummy/motor_dummy.py
@@ -24,6 +24,8 @@ import time
 from collections import OrderedDict
 from dataclasses import dataclass
 
+from qudi.core import ConfigOption
+
 from qudi.interface.motor_interface import MotorInterface
 
 
@@ -43,45 +45,19 @@ class MotorDummy(MotorInterface):
 
     motor_dummy:
         module.Class: 'dummy.motor_dummy.MotorDummy'
+        options:
+            # Time to wait after each movement in seconds.
+            wait_after_movement: 0.1
 
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    wait_after_movement: float = ConfigOption(default=0.1)
 
-        self.log.warning("This module has not been tested on the new qudi core."
-                         "Use with caution and contribute bug fixed back, please.")
-
-        # these label should be actually set by the config.
+    def on_activate(self):
         self._x_axis = MotorDummyAxis('x')
         self._y_axis = MotorDummyAxis('y')
         self._z_axis = MotorDummyAxis('z')
         self._phi_axis = MotorDummyAxis('phi')
-
-        self._wait_after_movement = 1 #in seconds
-
-    #TODO: Checks if configuration is set and is reasonable
-
-    def on_activate(self):
-
-        # PLEASE REMEMBER: DO NOT CALL THE POSITION SIMPLY self.x SINCE IT IS
-        # EXTREMLY DIFFICULT TO SEARCH FOR x GLOBALLY IN A FILE!
-        # Same applies to all other axis. I.e. choose more descriptive names.
-
-        self._x_axis.pos = 0.0
-        self._y_axis.pos = 0.0
-        self._z_axis.pos = 0.0
-        self._phi_axis.pos = 0.0
-
-        self._x_axis.vel = 1.0
-        self._y_axis.vel = 1.0
-        self._z_axis.vel = 1.0
-        self._phi_axis.vel = 1.0
-
-        self._x_axis.status = 0
-        self._y_axis.status = 0
-        self._z_axis.status = 0
-        self._phi_axis.status = 0
 
     def on_deactivate(self):
         pass

--- a/src/qudi/hardware/dummy/motor_dummy.py
+++ b/src/qudi/hardware/dummy/motor_dummy.py
@@ -196,15 +196,6 @@ class MotorDummy(MotorInterface):
 
 
     def move_abs(self, param_dict):
-        """ Moves stage to absolute position (absolute movement)
-
-        @param dict param_dict: dictionary, which passes all the relevant
-                                parameters, which should be changed. Usage:
-                                 {'axis_label': <a-value>}.
-                                 'axis_label' must correspond to a label given
-                                 to one of the axis.
-        A smart idea would be to ask the position after the movement.
-        """
         constraints = self.get_constraints()
 
         if param_dict.get(self._x_axis.label) is not None:
@@ -271,25 +262,10 @@ class MotorDummy(MotorInterface):
                 self._phi_axis.pos = desired_pos
 
     def abort(self):
-        """Stops movement of the stage
-
-        @return int: error code (0:OK, -1:error)
-        """
         self.log.info('MotorDummy: Movement stopped!')
         return 0
 
     def get_pos(self, param_list=None):
-        """ Gets current position of the stage arms
-
-        @param list param_list: optional, if a specific position of an axis
-                                is desired, then the labels of the needed
-                                axis should be passed as the param_list.
-                                If nothing is passed, then from each axis the
-                                position is asked.
-
-        @return dict: with keys being the axis labels and item the current
-                      position.
-        """
         pos = {}
         if param_list is not None:
             if self._x_axis.label in param_list:
@@ -313,17 +289,6 @@ class MotorDummy(MotorInterface):
         return pos
 
     def get_status(self, param_list=None):
-        """ Get the status of the position
-
-        @param list param_list: optional, if a specific status of an axis
-                                is desired, then the labels of the needed
-                                axis should be passed in the param_list.
-                                If nothing is passed, then from each axis the
-                                status is asked.
-
-        @return dict: with the axis label as key and the status number as item.
-        """
-
         status = {}
         if param_list is not None:
             if self._x_axis.label in param_list:
@@ -347,20 +312,6 @@ class MotorDummy(MotorInterface):
         return status
 
     def calibrate(self, param_list=None):
-        """ Calibrates the stage.
-
-        @param dict param_list: param_list: optional, if a specific calibration
-                                of an axis is desired, then the labels of the
-                                needed axis should be passed in the param_list.
-                                If nothing is passed, then all connected axis
-                                will be calibrated.
-
-        @return int: error code (0:OK, -1:error)
-
-        After calibration the stage moves to home position which will be the
-        zero point for the passed axis. The calibration procedure will be
-        different for each stage.
-        """
         if param_list is not None:
             if self._x_axis.label in param_list:
                 self._x_axis.pos = 0.0
@@ -383,16 +334,6 @@ class MotorDummy(MotorInterface):
         return 0
 
     def get_velocity(self, param_list=None):
-        """ Gets the current velocity for all connected axes.
-
-        @param dict param_list: optional, if a specific velocity of an axis
-                                is desired, then the labels of the needed
-                                axis should be passed as the param_list.
-                                If nothing is passed, then from each axis the
-                                velocity is asked.
-
-        @return dict : with the axis label as key and the velocity as item.
-        """
         vel = {}
         if param_list is not None:
             if self._x_axis.label in param_list:
@@ -413,14 +354,6 @@ class MotorDummy(MotorInterface):
         return vel
 
     def set_velocity(self, param_dict=None):
-        """ Write new value for velocity.
-
-        @param dict param_dict: dictionary, which passes all the relevant
-                                parameters, which should be changed. Usage:
-                                 {'axis_label': <the-velocity-value>}.
-                                 'axis_label' must correspond to a label given
-                                 to one of the axis.
-        """
         constraints = self.get_constraints()
 
         if param_dict.get(self._x_axis.label) is not None:
@@ -478,7 +411,6 @@ class MotorDummy(MotorInterface):
                             constr['pos_max']))
             else:
                 self._phi_axis.vel = desired_vel
-
 
     def _make_wait_after_movement(self):
         """ Define a time which the dummy should wait after each movement. """

--- a/src/qudi/hardware/dummy/motor_dummy.py
+++ b/src/qudi/hardware/dummy/motor_dummy.py
@@ -339,16 +339,16 @@ class MotorDummy(MotorInterface):
             if self._x_axis.label in param_list:
                 vel[self._x_axis.label] = self._x_axis.vel
             if self._y_axis.label in param_list:
-                vel[self._x_axis.label] = self._y_axis.vel
+                vel[self._y_axis.label] = self._y_axis.vel
             if self._z_axis.label in param_list:
-                vel[self._x_axis.label] = self._z_axis.vel
+                vel[self._z_axis.label] = self._z_axis.vel
             if self._phi_axis.label in param_list:
                 vel[self._phi_axis.label] = self._phi_axis.vel
 
         else:
-            vel[self._x_axis.label] = self._x_axis.get_vel
-            vel[self._y_axis.label] = self._y_axis.get_vel
-            vel[self._z_axis.label] = self._z_axis.get_vel
+            vel[self._x_axis.label] = self._x_axis.vel
+            vel[self._y_axis.label] = self._y_axis.vel
+            vel[self._z_axis.label] = self._z_axis.vel
             vel[self._phi_axis.label] = self._phi_axis.vel
 
         return vel
@@ -393,8 +393,8 @@ class MotorDummy(MotorInterface):
                         '"{0}" to possition {1}, since it exceeds the limits '
                         '[{2},{3}] ! Command is ignored!'.format(
                             self._z_axis.label, desired_vel,
-                            constr['pos_min'],
-                            constr['pos_max']))
+                            constr['vel_min'],
+                            constr['vel_max']))
             else:
                 self._z_axis.vel = desired_vel
 

--- a/src/qudi/hardware/dummy/motor_dummy.py
+++ b/src/qudi/hardware/dummy/motor_dummy.py
@@ -21,7 +21,6 @@ If not, see <https://www.gnu.org/licenses/>.
 """
 
 import time
-from collections import OrderedDict
 from dataclasses import dataclass
 
 from qudi.core import ConfigOption
@@ -63,29 +62,6 @@ class MotorDummy(MotorInterface):
         pass
 
     def get_constraints(self):
-        """ Retrieve the hardware constrains from the motor device.
-
-        @return dict: dict with constraints for the magnet hardware. These
-                      constraints will be passed via the logic to the GUI so
-                      that proper display elements with boundary conditions
-                      could be made.
-
-        Provides all the constraints for each axis of a motorized stage
-        (like total travel distance, velocity, ...)
-        Each axis has its own dictionary, where the label is used as the
-        identifier throughout the whole module. The dictionaries for each axis
-        are again grouped together in a constraints dictionary in the form
-
-            {'<label_axis0>': axis0 }
-
-        where axis0 is again a dict with the possible values defined below. The
-        possible keys in the constraint are defined here in the interface file.
-        If the hardware does not support the values for the constraints, then
-        insert just None. If you are not sure about the meaning, look in other
-        hardware files to get an impression.
-        """
-        constraints = OrderedDict()
-
         axis0 = {'label': self._x_axis.label,
                  'unit': 'm',
                  'ramp': ['Sinus', 'Linear'],
@@ -138,32 +114,14 @@ class MotorDummy(MotorInterface):
                  'acc_max': None,
                  'acc_step': None}
 
-        # assign the parameter container for x to a name which will identify it
-        constraints[axis0['label']] = axis0
-        constraints[axis1['label']] = axis1
-        constraints[axis2['label']] = axis2
-        constraints[axis3['label']] = axis3
-
-        return constraints
+        return {
+            axis0['label']: axis0,
+            axis1['label']: axis1,
+            axis2['label']: axis2,
+            axis3['label']: axis3
+        }
 
     def move_rel(self,  param_dict):
-        """ Moves stage in given direction (relative movement)
-
-        @param dict param_dict: dictionary, which passes all the relevant
-                                parameters, which should be changed.
-                                With get_constraints() you can obtain all
-                                possible parameters of that stage. According to
-                                this parameter set you have to pass a dictionary
-                                with keys that are called like the parameters
-                                from get_constraints() and assign a SI value to
-                                that. For a movement in x the dict should e.g.
-                                have the form:
-                                    dict = { 'x' : 23 }
-                                where the label 'x' corresponds to the chosen
-                                axis label.
-
-        A smart idea would be to ask the position after the movement.
-        """
         curr_pos_dict = self.get_pos()
         constraints = self.get_constraints()
 
@@ -524,5 +482,5 @@ class MotorDummy(MotorInterface):
 
     def _make_wait_after_movement(self):
         """ Define a time which the dummy should wait after each movement. """
-        time.sleep(self._wait_after_movement)
+        time.sleep(self.wait_after_movement)
 

--- a/src/qudi/interface/motor_interface.py
+++ b/src/qudi/interface/motor_interface.py
@@ -20,6 +20,8 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 
+from __future__ import annotations
+
 from abc import abstractmethod
 
 from qudi.core.module import Base
@@ -34,7 +36,7 @@ class MotorInterface(Base):
 
     @abstractmethod
     def get_constraints(self) -> dict[str, dict[str, float | str | list[str] | None]]:
-        """Retrieve the hardware constrains from the motor device.
+        """Retrieve the hardware constraints from the motor device.
 
         @return dict: dict with constraints for the magnet hardware. These
                       constraints will be passed via the logic to the GUI so

--- a/src/qudi/interface/motor_interface.py
+++ b/src/qudi/interface/motor_interface.py
@@ -26,15 +26,15 @@ from qudi.core.module import Base
 
 
 class MotorInterface(Base):
-    """ This is the Interface class to define the controls for the simple
-        step motor device. The actual hardware implementation might have a
-        different amount of axis. Implement each single axis as 'private'
-        methods for the hardware class, which get called by the general method.
+    """This is the Interface class to define the controls for the simple
+    step motor device. The actual hardware implementation might have a
+    different amount of axis. Implement each single axis as 'private'
+    methods for the hardware class, which get called by the general method.
     """
 
     @abstractmethod
-    def get_constraints(self):
-        """ Retrieve the hardware constrains from the motor device.
+    def get_constraints(self) -> dict[str, dict[str, float | str | list[str] | None]]:
+        """Retrieve the hardware constrains from the motor device.
 
         @return dict: dict with constraints for the magnet hardware. These
                       constraints will be passed via the logic to the GUI so
@@ -96,8 +96,8 @@ class MotorInterface(Base):
         pass
 
     @abstractmethod
-    def move_rel(self,  param_dict):
-        """ Moves stage in given direction (relative movement)
+    def move_rel(self, param_dict: dict[str, float]) -> None:
+        """Moves stage in given direction (relative movement)
 
         @param dict param_dict: dictionary, which passes all the relevant
                                 parameters, which should be changed. Usage:
@@ -106,36 +106,29 @@ class MotorInterface(Base):
                                  to one of the axis.
 
         A smart idea would be to ask the position after the movement.
-
-        @return int: error code (0:OK, -1:error)
         """
         pass
 
     @abstractmethod
-    def move_abs(self, param_dict):
-        """ Moves stage to absolute position (absolute movement)
+    def move_abs(self, param_dict: dict[str, float]) -> None:
+        """Moves stage to absolute position (absolute movement)
 
         @param dict param_dict: dictionary, which passes all the relevant
                                 parameters, which should be changed. Usage:
                                  {'axis_label': <the-abs-pos-value>}.
                                  'axis_label' must correspond to a label given
                                  to one of the axis.
-
-        @return int: error code (0:OK, -1:error)
         """
         pass
 
     @abstractmethod
-    def abort(self):
-        """ Stops movement of the stage
-
-        @return int: error code (0:OK, -1:error)
-        """
+    def abort(self) -> None:
+        """Stops movement of the stage"""
         pass
 
     @abstractmethod
-    def get_pos(self, param_list=None):
-        """ Gets current position of the stage arms
+    def get_pos(self, param_list: list[str] | None = None) -> dict[str, float]:
+        """Gets current position of the stage arms
 
         @param list param_list: optional, if a specific position of an axis
                                 is desired, then the labels of the needed
@@ -149,8 +142,8 @@ class MotorInterface(Base):
         pass
 
     @abstractmethod
-    def get_status(self, param_list=None):
-        """ Get the status of the position
+    def get_status(self, param_list: list[str] | None = None) -> dict[str, int]:
+        """Get the status of the position
 
         @param list param_list: optional, if a specific status of an axis
                                 is desired, then the labels of the needed
@@ -163,16 +156,14 @@ class MotorInterface(Base):
         pass
 
     @abstractmethod
-    def calibrate(self, param_list=None):
-        """ Calibrates the stage.
+    def calibrate(self, param_list: list[str] | None = None) -> None:
+        """Calibrates the stage.
 
-        @param dict param_list: param_list: optional, if a specific calibration
+        @param list param_list: optional, if a specific calibration
                                 of an axis is desired, then the labels of the
                                 needed axis should be passed in the param_list.
                                 If nothing is passed, then all connected axis
                                 will be calibrated.
-
-        @return int: error code (0:OK, -1:error)
 
         After calibration the stage moves to home position which will be the
         zero point for the passed axis. The calibration procedure will be
@@ -181,10 +172,10 @@ class MotorInterface(Base):
         pass
 
     @abstractmethod
-    def get_velocity(self, param_list=None):
-        """ Gets the current velocity for all connected axes.
+    def get_velocity(self, param_list: list[str] | None = None) -> dict[str, float]:
+        """Gets the current velocity for all connected axes.
 
-        @param dict param_list: optional, if a specific velocity of an axis
+        @param list param_list: optional, if a specific velocity of an axis
                                 is desired, then the labels of the needed
                                 axis should be passed as the param_list.
                                 If nothing is passed, then from each axis the
@@ -195,15 +186,13 @@ class MotorInterface(Base):
         pass
 
     @abstractmethod
-    def set_velocity(self, param_dict):
-        """ Write new value for velocity.
+    def set_velocity(self, param_dict: dict[str, float]) -> None:
+        """Write new value for velocity.
 
         @param dict param_dict: dictionary, which passes all the relevant
                                 parameters, which should be changed. Usage:
                                  {'axis_label': <the-velocity-value>}.
                                  'axis_label' must correspond to a label given
                                  to one of the axis.
-
-        @return int: error code (0:OK, -1:error)
         """
         pass


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
Fixed several significant issues with the motor dummy and significantly simplified the code.
- Fixed broken MRO.
- Fixed `get_velocity` incorrectly accessing `get_vel` attribute of some axes (instead of `vel`).
- Fixed `get_velocity` accessing the wrong axes when a parameter list was supplied.

Also cleaned up the interface and added type hints. Removed status code return, as almost no modules properly makes use of this.

Resolves https://github.com/SparrowQuantum/qudi-sparrowlab-modules/issues/147

## Motivation and Context
Attempting to set up a proper all-inclusive dummy config in `qudi-sparrowlab-modules` won't work without a motor dummy.

## How Has This Been Tested?
Tested by loading in Qudi and manually verifying behavior of each method.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
