### PR TITLE
Fix: PID gui spinbox bug (with pyside6)

### DIFF
--- a/src/qudi/gui/pidgui/pidgui.py
+++ b/src/qudi/gui/pidgui/pidgui.py
@@ -189,12 +189,12 @@ class PIDGui(GuiBase):
         self._mw.reset_view_Action.triggered.connect(self._reset_clicked)
         self._mw.record_control_Action.triggered.connect(self._save_clicked)
 
-        self._mw.P_DoubleSpinBox.editingFinished.connect(self._kp_changed)
-        self._mw.I_DoubleSpinBox.editingFinished.connect(self._ki_changed)
-        self._mw.D_DoubleSpinBox.editingFinished.connect(self._kd_changed)
+        self._mw.P_DoubleSpinBox.lineEdit().returnPressed.connect(self._kp_changed)
+        self._mw.I_DoubleSpinBox.lineEdit().returnPressed.connect(self._ki_changed)
+        self._mw.D_DoubleSpinBox.lineEdit().returnPressed.connect(self._kd_changed)
 
         self._mw.setpointDoubleSpinBox.lineEdit().returnPressed.connect(self._setpoint_changed)
-        self._mw.manualDoubleSpinBox.editingFinished.connect(self._manual_value_changed)
+        self._mw.manualDoubleSpinBox.lineEdit().returnPressed.connect(self._manual_value_changed)
         self._mw.pidEnabledCheckBox.toggled.connect(self._pid_enabled_changed)
 
         # Connect the default view action
@@ -239,8 +239,6 @@ class PIDGui(GuiBase):
             self._mw.control_value_Label.setText(f'<font color={palette.c3.name()}>{cv}</font>')
             self._mw.setpoint_value_Label.setText(f'<font color={palette.c2.name()}>{sp}</font>')
 
-            if not self._mw.setpointDoubleSpinBox.hasFocus():
-                self._mw.setpointDoubleSpinBox.setValue(self._pid_logic.get_setpoint())
 
             extra = self._pid_logic._controller.get_extra()
             if 'P' in extra:

--- a/src/qudi/gui/pidgui/pidgui.py
+++ b/src/qudi/gui/pidgui/pidgui.py
@@ -194,7 +194,6 @@ class PIDGui(GuiBase):
         self._mw.D_DoubleSpinBox.editingFinished.connect(self._kd_changed)
 
         self._mw.setpointPushButton.clicked.connect(self._setpoint_changed)
-        self._mw.setpointDoubleSpinBox.editingFinished.connect(self._setpoint_changed)
         self._mw.manualDoubleSpinBox.editingFinished.connect(self._manual_value_changed)
         self._mw.pidEnabledCheckBox.toggled.connect(self._pid_enabled_changed)
 

--- a/src/qudi/gui/pidgui/pidgui.py
+++ b/src/qudi/gui/pidgui/pidgui.py
@@ -35,7 +35,7 @@ from qudi.logic.pid_logic import PIDLogic
 
 
 class PIDMainWindow(QtWidgets.QMainWindow):
-    """Create the Main Window based on the *.ui file."""
+    """ Create the Main Window based on the *.ui file. """
 
     def __init__(self):
         # Get the path to the *.ui file
@@ -49,7 +49,7 @@ class PIDMainWindow(QtWidgets.QMainWindow):
 
 
 class PIDGui(GuiBase):
-    """Gui module to monitor and control a PID process
+    """ Gui module to monitor and control a PID process
 
     Example config:
 
@@ -84,7 +84,9 @@ class PIDGui(GuiBase):
         self._curve3 = None
 
     def on_activate(self):
-        """Definition and initialisation of the GUI plus staring the measurement."""
+        """ Definition and initialisation of the GUI plus staring the measurement.
+
+        """
         self._pid_logic = self.pidlogic()
 
         #####################
@@ -107,13 +109,15 @@ class PIDGui(GuiBase):
         self.plot1.setLabel(
             'left',
             '<font color={0}>Process Value</font> and <font color={1}>Setpoint</font>'.format(
-                palette.c1.name(), palette.c2.name()
-            ),
-            units=self.process_value_unit,
-        )
+                palette.c1.name(),
+                palette.c2.name()),
+            units=self.process_value_unit)
         self.plot1.setLabel('bottom', 'Time', units='s')
         self.plot1.showAxis('right')
-        self.plot1.getAxis('right').setLabel('Control Value', units=self.control_value_unit, color=palette.c3.name())
+        self.plot1.getAxis('right').setLabel(
+            'Control Value',
+            units=self.control_value_unit,
+            color=palette.c3.name())
 
         self.plot2 = pg.ViewBox()
         self.plot1.scene().addItem(self.plot2)
@@ -121,34 +125,35 @@ class PIDGui(GuiBase):
         self.plot2.setXLink(self.plot1)
 
         ## Create an empty plot curve to be filled later, set its pen
-        self._curve1 = pg.PlotDataItem(
-            pen=pg.mkPen(palette.c1),  # , style=QtCore.Qt.DotLine),
-            symbol=None,
-            # symbol='o',
-            # symbolPen=palette.c1,
-            # symbolBrush=palette.c1,
-            # symbolSize=3
-        )
+        self._curve1 = pg.PlotDataItem(pen=pg.mkPen(palette.c1),#, style=QtCore.Qt.DotLine),
+                                       symbol=None,
+                                       #symbol='o',
+                                       #symbolPen=palette.c1,
+                                       #symbolBrush=palette.c1,
+                                       #symbolSize=3
+                                       )
 
-        self._curve3 = pg.PlotDataItem(pen=pg.mkPen(palette.c2), symbol=None)
+        self._curve3 = pg.PlotDataItem(pen=pg.mkPen(palette.c2),
+                                       symbol=None
+                                       )
 
-        self._curve2 = pg.PlotDataItem(
-            pen=pg.mkPen(palette.c3),  # , style=QtCore.Qt.DotLine),
-            symbol=None,
-            # symbol='o',
-            # symbolPen=palette.c3,
-            # symbolBrush=palette.c3,
-            # symbolSize=3
-        )
+        self._curve2 = pg.PlotDataItem(pen=pg.mkPen(palette.c3),#, style=QtCore.Qt.DotLine),
+                                       symbol=None,
+                                       #symbol='o',
+                                       #symbolPen=palette.c3,
+                                       #symbolBrush=palette.c3,
+                                       #symbolSize=3
+                                       )
 
-        #        self._curve1 = pg.PlotCurveItem()
-        #        self._curve1.setPen(palette.c1)
+#        self._curve1 = pg.PlotCurveItem()
+#        self._curve1.setPen(palette.c1)
 
-        #        self._curve3 = pg.PlotCurveItem()
-        #        self._curve3.setPen(palette.c2)
+#        self._curve3 = pg.PlotCurveItem()
+#        self._curve3.setPen(palette.c2)
 
-        #        self._curve2 = pg.PlotCurveItem()
-        #        self._curve2.setPen(palette.c3)
+#        self._curve2 = pg.PlotCurveItem()
+#        self._curve2.setPen(palette.c3)
+
 
         self.plot1.addItem(self._curve1)
         self.plot1.addItem(self._curve3)
@@ -202,32 +207,32 @@ class PIDGui(GuiBase):
         self._pid_logic.sigUpdateDisplay.connect(self._update_data)
 
     def show(self):
-        """Make window visible and put it above all other windows."""
+        """Make window visible and put it above all other windows.
+        """
         QtWidgets.QMainWindow.show(self._mw)
         self._mw.activateWindow()
         self._mw.raise_()
 
     def on_deactivate(self):
-        """Deactivate the module properly."""
+        """Deactivate the module properly.
+        """
         # FIXME: !
         self._mw.close()
 
     def _update_data(self):
-        """The function that grabs the data and sends it to the plot."""
+        """The function that grabs the data and sends it to the plot.
+        """
 
         if self._pid_logic.is_recording:
             # format display values with unit
-            pv = create_formatted_output(
-                {'Process': {'value': self._pid_logic.get_pv(), 'unit': self.process_value_unit}}
-            )
+            pv = create_formatted_output({'Process': {'value': self._pid_logic.get_pv(),
+                                                      'unit': self.process_value_unit}})
             pv = pv.split(': ')[1]
-            cv = create_formatted_output(
-                {'Control': {'value': self._pid_logic.get_cv(), 'unit': self.control_value_unit}}
-            )
+            cv = create_formatted_output({'Control': {'value': self._pid_logic.get_cv(),
+                                                      'unit': self.control_value_unit}})
             cv = cv.split(': ')[1]
-            sp = create_formatted_output(
-                {'Setpoint': {'value': self._pid_logic.get_setpoint(), 'unit': self.process_value_unit}}
-            )
+            sp = create_formatted_output({'Setpoint': {'value': self._pid_logic.get_setpoint(),
+                                                       'unit': self.process_value_unit}})
             sp = sp.split(': ')[1]
 
             self._mw.process_value_Label.setText(f'<font color={palette.c1.name()}>{pv}</font>')
@@ -243,16 +248,16 @@ class PIDGui(GuiBase):
                 self._mw.labelkD.setText('{0:,.6f}'.format(extra['D']))
             self._curve1.setData(
                 y=self._pid_logic.history[0],
-                x=np.arange(0, self._pid_logic.get_buffer_length()) * self._pid_logic.timestep,
-            )
+                x=np.arange(0, self._pid_logic.get_buffer_length()) * self._pid_logic.timestep
+                )
             self._curve2.setData(
                 y=self._pid_logic.history[1],
-                x=np.arange(0, self._pid_logic.get_buffer_length()) * self._pid_logic.timestep,
-            )
+                x=np.arange(0, self._pid_logic.get_buffer_length()) * self._pid_logic.timestep
+                )
             self._curve3.setData(
                 y=self._pid_logic.history[2],
-                x=np.arange(0, self._pid_logic.get_buffer_length()) * self._pid_logic.timestep,
-            )
+                x=np.arange(0, self._pid_logic.get_buffer_length()) * self._pid_logic.timestep
+                )
 
         if self._pid_logic.get_saving_state():
             self._mw.record_control_Action.setText('Save')
@@ -265,7 +270,7 @@ class PIDGui(GuiBase):
             self._mw.start_control_Action.setText('Start')
 
     def _update_views(self):
-        ## view has resized; update auxiliary views to match
+    ## view has resized; update auxiliary views to match
         self.plot2.setGeometry(self.plot1.vb.sceneBoundingRect())
 
         ## need to re-update linked axes since this was called
@@ -274,7 +279,8 @@ class PIDGui(GuiBase):
         self.plot2.linkedViewChanged(self.plot1.vb, self.plot2.XAxis)
 
     def _start_clicked(self):
-        """Handling the Start button to stop and restart the counter."""
+        """Handling the Start button to stop and restart the counter.
+        """
         if self._pid_logic.is_recording:
             self._mw.start_control_Action.setText('Start')
             self.sigStop.emit()
@@ -283,12 +289,14 @@ class PIDGui(GuiBase):
             self.sigStart.emit()
 
     def _reset_clicked(self):
-        """Handling the reset view button to reset the plot."""
+        """Handling the reset view button to reset the plot.
+        """
         self._pid_logic.reset_buffer()
         self._update_data()
 
     def _save_clicked(self):
-        """Handling the save button to save the data into a file."""
+        """Handling the save button to save the data into a file.
+        """
         if self._pid_logic.get_saving_state():
             self._mw.record_counts_Action.setText('Start Saving Data')
             self._pid_logic.save_data()
@@ -297,7 +305,8 @@ class PIDGui(GuiBase):
             self._pid_logic.start_saving()
 
     def _restore_default_view(self):
-        """Restore the arrangement of DockWidgets to the default"""
+        """Restore the arrangement of DockWidgets to the default
+        """
         # Show any hidden dock widgets
         self._mw.pid_trace_DockWidget.show()
         self._mw.pid_parameters_DockWidget.show()

--- a/src/qudi/gui/pidgui/pidgui.py
+++ b/src/qudi/gui/pidgui/pidgui.py
@@ -193,7 +193,7 @@ class PIDGui(GuiBase):
         self._mw.I_DoubleSpinBox.editingFinished.connect(self._ki_changed)
         self._mw.D_DoubleSpinBox.editingFinished.connect(self._kd_changed)
 
-        self._mw.setpointDoubleSpinBox.editingFinished.connect(self._setpoint_changed)
+        self._mw.setpointPushButton.clicked.connect(self._setpoint_changed)
         self._mw.manualDoubleSpinBox.editingFinished.connect(self._manual_value_changed)
         self._mw.pidEnabledCheckBox.toggled.connect(self._pid_enabled_changed)
 

--- a/src/qudi/gui/pidgui/pidgui.py
+++ b/src/qudi/gui/pidgui/pidgui.py
@@ -193,6 +193,7 @@ class PIDGui(GuiBase):
         self._mw.I_DoubleSpinBox.editingFinished.connect(self._ki_changed)
         self._mw.D_DoubleSpinBox.editingFinished.connect(self._kd_changed)
 
+        self._mw.setpointDoubleSpinBox.lineEdit().returnPressed.connect(self._setpoint_changed)
         self._mw.setpointPushButton.clicked.connect(self._setpoint_changed)
         self._mw.manualDoubleSpinBox.editingFinished.connect(self._manual_value_changed)
         self._mw.pidEnabledCheckBox.toggled.connect(self._pid_enabled_changed)

--- a/src/qudi/gui/pidgui/pidgui.py
+++ b/src/qudi/gui/pidgui/pidgui.py
@@ -239,6 +239,9 @@ class PIDGui(GuiBase):
             self._mw.control_value_Label.setText(f'<font color={palette.c3.name()}>{cv}</font>')
             self._mw.setpoint_value_Label.setText(f'<font color={palette.c2.name()}>{sp}</font>')
 
+            if not self._mw.setpointDoubleSpinBox.hasFocus():
+                self._mw.setpointDoubleSpinBox.setValue(self._pid_logic.get_setpoint())
+
             extra = self._pid_logic._controller.get_extra()
             if 'P' in extra:
                 self._mw.labelkP.setText('{0:,.6f}'.format(extra['P']))

--- a/src/qudi/gui/pidgui/pidgui.py
+++ b/src/qudi/gui/pidgui/pidgui.py
@@ -194,7 +194,6 @@ class PIDGui(GuiBase):
         self._mw.D_DoubleSpinBox.editingFinished.connect(self._kd_changed)
 
         self._mw.setpointDoubleSpinBox.lineEdit().returnPressed.connect(self._setpoint_changed)
-        self._mw.setpointPushButton.clicked.connect(self._setpoint_changed)
         self._mw.manualDoubleSpinBox.editingFinished.connect(self._manual_value_changed)
         self._mw.pidEnabledCheckBox.toggled.connect(self._pid_enabled_changed)
 

--- a/src/qudi/gui/pidgui/pidgui.py
+++ b/src/qudi/gui/pidgui/pidgui.py
@@ -194,6 +194,7 @@ class PIDGui(GuiBase):
         self._mw.D_DoubleSpinBox.editingFinished.connect(self._kd_changed)
 
         self._mw.setpointPushButton.clicked.connect(self._setpoint_changed)
+        self._mw.setpointDoubleSpinBox.editingFinished.connect(self._setpoint_changed)
         self._mw.manualDoubleSpinBox.editingFinished.connect(self._manual_value_changed)
         self._mw.pidEnabledCheckBox.toggled.connect(self._pid_enabled_changed)
 
@@ -332,8 +333,7 @@ class PIDGui(GuiBase):
         self._pid_logic.set_kd(self._mw.D_DoubleSpinBox.value())
 
     def _setpoint_changed(self):
-        if self._mw.pidEnabledCheckBox.checkState() == QtCore.Qt.CheckState.Checked:
-            self._pid_logic.set_setpoint(self._mw.setpointDoubleSpinBox.value())
+        self._pid_logic.set_setpoint(self._mw.setpointDoubleSpinBox.value())
 
     def _manual_value_changed(self):
         if self._mw.pidEnabledCheckBox.checkState() == QtCore.Qt.CheckState.Unchecked:

--- a/src/qudi/gui/pidgui/pidgui.py
+++ b/src/qudi/gui/pidgui/pidgui.py
@@ -35,7 +35,7 @@ from qudi.logic.pid_logic import PIDLogic
 
 
 class PIDMainWindow(QtWidgets.QMainWindow):
-    """ Create the Main Window based on the *.ui file. """
+    """Create the Main Window based on the *.ui file."""
 
     def __init__(self):
         # Get the path to the *.ui file
@@ -49,7 +49,7 @@ class PIDMainWindow(QtWidgets.QMainWindow):
 
 
 class PIDGui(GuiBase):
-    """ Gui module to monitor and control a PID process
+    """Gui module to monitor and control a PID process
 
     Example config:
 
@@ -84,9 +84,7 @@ class PIDGui(GuiBase):
         self._curve3 = None
 
     def on_activate(self):
-        """ Definition and initialisation of the GUI plus staring the measurement.
-
-        """
+        """Definition and initialisation of the GUI plus staring the measurement."""
         self._pid_logic = self.pidlogic()
 
         #####################
@@ -109,15 +107,13 @@ class PIDGui(GuiBase):
         self.plot1.setLabel(
             'left',
             '<font color={0}>Process Value</font> and <font color={1}>Setpoint</font>'.format(
-                palette.c1.name(),
-                palette.c2.name()),
-            units=self.process_value_unit)
+                palette.c1.name(), palette.c2.name()
+            ),
+            units=self.process_value_unit,
+        )
         self.plot1.setLabel('bottom', 'Time', units='s')
         self.plot1.showAxis('right')
-        self.plot1.getAxis('right').setLabel(
-            'Control Value',
-            units=self.control_value_unit,
-            color=palette.c3.name())
+        self.plot1.getAxis('right').setLabel('Control Value', units=self.control_value_unit, color=palette.c3.name())
 
         self.plot2 = pg.ViewBox()
         self.plot1.scene().addItem(self.plot2)
@@ -125,35 +121,34 @@ class PIDGui(GuiBase):
         self.plot2.setXLink(self.plot1)
 
         ## Create an empty plot curve to be filled later, set its pen
-        self._curve1 = pg.PlotDataItem(pen=pg.mkPen(palette.c1),#, style=QtCore.Qt.DotLine),
-                                       symbol=None
-                                       #symbol='o',
-                                       #symbolPen=palette.c1,
-                                       #symbolBrush=palette.c1,
-                                       #symbolSize=3
-                                       )
+        self._curve1 = pg.PlotDataItem(
+            pen=pg.mkPen(palette.c1),  # , style=QtCore.Qt.DotLine),
+            symbol=None,
+            # symbol='o',
+            # symbolPen=palette.c1,
+            # symbolBrush=palette.c1,
+            # symbolSize=3
+        )
 
-        self._curve3 = pg.PlotDataItem(pen=pg.mkPen(palette.c2),
-                                       symbol=None
-                                       )
+        self._curve3 = pg.PlotDataItem(pen=pg.mkPen(palette.c2), symbol=None)
 
-        self._curve2 = pg.PlotDataItem(pen=pg.mkPen(palette.c3),#, style=QtCore.Qt.DotLine),
-                                       symbol=None
-                                       #symbol='o',
-                                       #symbolPen=palette.c3,
-                                       #symbolBrush=palette.c3,
-                                       #symbolSize=3
-                                       )
+        self._curve2 = pg.PlotDataItem(
+            pen=pg.mkPen(palette.c3),  # , style=QtCore.Qt.DotLine),
+            symbol=None,
+            # symbol='o',
+            # symbolPen=palette.c3,
+            # symbolBrush=palette.c3,
+            # symbolSize=3
+        )
 
-#        self._curve1 = pg.PlotCurveItem()
-#        self._curve1.setPen(palette.c1)
+        #        self._curve1 = pg.PlotCurveItem()
+        #        self._curve1.setPen(palette.c1)
 
-#        self._curve3 = pg.PlotCurveItem()
-#        self._curve3.setPen(palette.c2)
+        #        self._curve3 = pg.PlotCurveItem()
+        #        self._curve3.setPen(palette.c2)
 
-#        self._curve2 = pg.PlotCurveItem()
-#        self._curve2.setPen(palette.c3)
-
+        #        self._curve2 = pg.PlotCurveItem()
+        #        self._curve2.setPen(palette.c3)
 
         self.plot1.addItem(self._curve1)
         self.plot1.addItem(self._curve3)
@@ -207,38 +202,37 @@ class PIDGui(GuiBase):
         self._pid_logic.sigUpdateDisplay.connect(self._update_data)
 
     def show(self):
-        """Make window visible and put it above all other windows.
-        """
+        """Make window visible and put it above all other windows."""
         QtWidgets.QMainWindow.show(self._mw)
         self._mw.activateWindow()
         self._mw.raise_()
 
     def on_deactivate(self):
-        """ Deactivate the module properly.
-        """
+        """Deactivate the module properly."""
         # FIXME: !
         self._mw.close()
 
     def _update_data(self):
-        """ The function that grabs the data and sends it to the plot.
-        """
+        """The function that grabs the data and sends it to the plot."""
 
         if self._pid_logic.is_recording:
             # format display values with unit
-            pv = create_formatted_output({'Process': {'value': self._pid_logic.get_pv(),
-                                                      'unit': self.process_value_unit}})
+            pv = create_formatted_output(
+                {'Process': {'value': self._pid_logic.get_pv(), 'unit': self.process_value_unit}}
+            )
             pv = pv.split(': ')[1]
-            cv = create_formatted_output({'Control': {'value': self._pid_logic.get_cv(),
-                                                      'unit': self.control_value_unit}})
+            cv = create_formatted_output(
+                {'Control': {'value': self._pid_logic.get_cv(), 'unit': self.control_value_unit}}
+            )
             cv = cv.split(': ')[1]
-            sp = create_formatted_output({'Setpoint': {'value': self._pid_logic.get_setpoint(),
-                                                       'unit': self.process_value_unit}})
+            sp = create_formatted_output(
+                {'Setpoint': {'value': self._pid_logic.get_setpoint(), 'unit': self.process_value_unit}}
+            )
             sp = sp.split(': ')[1]
 
             self._mw.process_value_Label.setText(f'<font color={palette.c1.name()}>{pv}</font>')
             self._mw.control_value_Label.setText(f'<font color={palette.c3.name()}>{cv}</font>')
             self._mw.setpoint_value_Label.setText(f'<font color={palette.c2.name()}>{sp}</font>')
-
 
             extra = self._pid_logic._controller.get_extra()
             if 'P' in extra:
@@ -249,16 +243,16 @@ class PIDGui(GuiBase):
                 self._mw.labelkD.setText('{0:,.6f}'.format(extra['D']))
             self._curve1.setData(
                 y=self._pid_logic.history[0],
-                x=np.arange(0, self._pid_logic.get_buffer_length()) * self._pid_logic.timestep
-                )
+                x=np.arange(0, self._pid_logic.get_buffer_length()) * self._pid_logic.timestep,
+            )
             self._curve2.setData(
                 y=self._pid_logic.history[1],
-                x=np.arange(0, self._pid_logic.get_buffer_length()) * self._pid_logic.timestep
-                )
+                x=np.arange(0, self._pid_logic.get_buffer_length()) * self._pid_logic.timestep,
+            )
             self._curve3.setData(
                 y=self._pid_logic.history[2],
-                x=np.arange(0, self._pid_logic.get_buffer_length()) * self._pid_logic.timestep
-                )
+                x=np.arange(0, self._pid_logic.get_buffer_length()) * self._pid_logic.timestep,
+            )
 
         if self._pid_logic.get_saving_state():
             self._mw.record_control_Action.setText('Save')
@@ -271,7 +265,7 @@ class PIDGui(GuiBase):
             self._mw.start_control_Action.setText('Start')
 
     def _update_views(self):
-    ## view has resized; update auxiliary views to match
+        ## view has resized; update auxiliary views to match
         self.plot2.setGeometry(self.plot1.vb.sceneBoundingRect())
 
         ## need to re-update linked axes since this was called
@@ -280,8 +274,7 @@ class PIDGui(GuiBase):
         self.plot2.linkedViewChanged(self.plot1.vb, self.plot2.XAxis)
 
     def _start_clicked(self):
-        """ Handling the Start button to stop and restart the counter.
-        """
+        """Handling the Start button to stop and restart the counter."""
         if self._pid_logic.is_recording:
             self._mw.start_control_Action.setText('Start')
             self.sigStop.emit()
@@ -290,14 +283,12 @@ class PIDGui(GuiBase):
             self.sigStart.emit()
 
     def _reset_clicked(self):
-        """ Handling the reset view button to reset the plot.
-        """
+        """Handling the reset view button to reset the plot."""
         self._pid_logic.reset_buffer()
         self._update_data()
 
     def _save_clicked(self):
-        """ Handling the save button to save the data into a file.
-        """
+        """Handling the save button to save the data into a file."""
         if self._pid_logic.get_saving_state():
             self._mw.record_counts_Action.setText('Start Saving Data')
             self._pid_logic.save_data()
@@ -306,8 +297,7 @@ class PIDGui(GuiBase):
             self._pid_logic.start_saving()
 
     def _restore_default_view(self):
-        """ Restore the arrangement of DockWidgets to the default
-        """
+        """Restore the arrangement of DockWidgets to the default"""
         # Show any hidden dock widgets
         self._mw.pid_trace_DockWidget.show()
         self._mw.pid_parameters_DockWidget.show()
@@ -330,7 +320,8 @@ class PIDGui(GuiBase):
         self._pid_logic.set_kd(self._mw.D_DoubleSpinBox.value())
 
     def _setpoint_changed(self):
-        self._pid_logic.set_setpoint(self._mw.setpointDoubleSpinBox.value())
+        if self._mw.pidEnabledCheckBox.checkState() == QtCore.Qt.CheckState.Checked:
+            self._pid_logic.set_setpoint(self._mw.setpointDoubleSpinBox.value())
 
     def _manual_value_changed(self):
         if self._mw.pidEnabledCheckBox.checkState() == QtCore.Qt.CheckState.Unchecked:

--- a/src/qudi/gui/pidgui/pidgui.py
+++ b/src/qudi/gui/pidgui/pidgui.py
@@ -126,7 +126,7 @@ class PIDGui(GuiBase):
 
         ## Create an empty plot curve to be filled later, set its pen
         self._curve1 = pg.PlotDataItem(pen=pg.mkPen(palette.c1),#, style=QtCore.Qt.DotLine),
-                                       symbol=None,
+                                       symbol=None
                                        #symbol='o',
                                        #symbolPen=palette.c1,
                                        #symbolBrush=palette.c1,
@@ -138,7 +138,7 @@ class PIDGui(GuiBase):
                                        )
 
         self._curve2 = pg.PlotDataItem(pen=pg.mkPen(palette.c3),#, style=QtCore.Qt.DotLine),
-                                       symbol=None,
+                                       symbol=None
                                        #symbol='o',
                                        #symbolPen=palette.c3,
                                        #symbolBrush=palette.c3,
@@ -214,13 +214,13 @@ class PIDGui(GuiBase):
         self._mw.raise_()
 
     def on_deactivate(self):
-        """Deactivate the module properly.
+        """ Deactivate the module properly.
         """
         # FIXME: !
         self._mw.close()
 
     def _update_data(self):
-        """The function that grabs the data and sends it to the plot.
+        """ The function that grabs the data and sends it to the plot.
         """
 
         if self._pid_logic.is_recording:
@@ -279,7 +279,7 @@ class PIDGui(GuiBase):
         self.plot2.linkedViewChanged(self.plot1.vb, self.plot2.XAxis)
 
     def _start_clicked(self):
-        """Handling the Start button to stop and restart the counter.
+        """ Handling the Start button to stop and restart the counter.
         """
         if self._pid_logic.is_recording:
             self._mw.start_control_Action.setText('Start')
@@ -289,13 +289,13 @@ class PIDGui(GuiBase):
             self.sigStart.emit()
 
     def _reset_clicked(self):
-        """Handling the reset view button to reset the plot.
+        """ Handling the reset view button to reset the plot.
         """
         self._pid_logic.reset_buffer()
         self._update_data()
 
     def _save_clicked(self):
-        """Handling the save button to save the data into a file.
+        """ Handling the save button to save the data into a file.
         """
         if self._pid_logic.get_saving_state():
             self._mw.record_counts_Action.setText('Start Saving Data')
@@ -305,7 +305,7 @@ class PIDGui(GuiBase):
             self._pid_logic.start_saving()
 
     def _restore_default_view(self):
-        """Restore the arrangement of DockWidgets to the default
+        """ Restore the arrangement of DockWidgets to the default
         """
         # Show any hidden dock widgets
         self._mw.pid_trace_DockWidget.show()

--- a/src/qudi/gui/pidgui/ui_pid_control.ui
+++ b/src/qudi/gui/pidgui/ui_pid_control.ui
@@ -502,19 +502,6 @@ Timestamps in oversampling interval are all equal to the averaging time.</string
        </property>
       </widget>
      </item>
-     <item row="0" column="4">
-      <widget class="QPushButton" name="setpointPushButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Set</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="5">
       <spacer name="horizontalSpacer_3">
        <property name="orientation">

--- a/src/qudi/gui/pidgui/ui_pid_control.ui
+++ b/src/qudi/gui/pidgui/ui_pid_control.ui
@@ -503,6 +503,19 @@ Timestamps in oversampling interval are all equal to the averaging time.</string
       </widget>
      </item>
      <item row="0" column="4">
+      <widget class="QPushButton" name="setpointPushButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Set</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
       <spacer name="horizontalSpacer_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/src/qudi/logic/pid_logic.py
+++ b/src/qudi/logic/pid_logic.py
@@ -27,7 +27,7 @@ from qudi.core.statusvariable import StatusVar
 from qudi.core.configoption import ConfigOption
 from qudi.util.mutex import Mutex
 from qudi.core.module import LogicBase
-from PySide2 import QtCore
+from PySide6 import QtCore
 
 from qudi.interface.pid_controller_interface import PIDControllerInterface
 


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
<!--- Describe your changes in detail -->
All double spinboxes of the pid gui are now activated when Return is pressed, instead of when the editing of the value is finished. Also, in pid_logic.py PySide2 was replaced with PySide6.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Activating the function that is connected to the spinbox when editing is finished introduces weird interactions e.g. editing is finished when the spin box goes out of focus (for example by clicking on a different widget of the gui).

There is an open issue about this on qudi-sparrowlab-modules:
https://github.com/SparrowQuantum/qudi-sparrowlab-modules/issues/177

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Code was tested with the pid dummy module together with Jeppe.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
