### PR TITLE
Feat: Pidgui window title based on module name

### DIFF
--- a/src/qudi/gui/pidgui/pidgui.py
+++ b/src/qudi/gui/pidgui/pidgui.py
@@ -37,7 +37,7 @@ from qudi.logic.pid_logic import PIDLogic
 class PIDMainWindow(QtWidgets.QMainWindow):
     """ Create the Main Window based on the *.ui file. """
 
-    def __init__(self):
+    def __init__(self, window_title: str = 'Qudi: Pid Control'):
         # Get the path to the *.ui file
         this_dir = os.path.dirname(__file__)
         ui_file = os.path.join(this_dir, 'ui_pid_control.ui')
@@ -45,6 +45,7 @@ class PIDMainWindow(QtWidgets.QMainWindow):
         # Load it
         super().__init__()
         uic.loadUi(ui_file, self)
+        self.setWindowTitle(window_title)
         self.show()
 
 
@@ -91,8 +92,9 @@ class PIDGui(GuiBase):
 
         #####################
         # Configuring the dock widgets
-        # Use the inherited class 'CounterMainWindow' to create the GUI window
-        self._mw = PIDMainWindow()
+        # Use the inherited class 'PIDMainWindow' to create the GUI window
+        window_title = f"Qudi: {self.module_name.replace('_', ' ').title()}"
+        self._mw = PIDMainWindow(window_title=window_title)
 
         # Setup dock widgets
         self._mw.centralwidget.hide()


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
Makes the window title of the pid gui follow the name of the module it's loaded from.

## Motivation and Context
Makes it easier to distinguish windows if there is more than one pid gui present.

## How Has This Been Tested?
Tested with `default.cfg`, `just build` recipe passes.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
